### PR TITLE
Embed IANA tzdata to fix startup crash on machines without Go installed

### DIFF
--- a/HebcalNative/lib/hebcal_export.go
+++ b/HebcalNative/lib/hebcal_export.go
@@ -16,6 +16,8 @@ import (
 	"time"
 	"unsafe"
 
+	_ "time/tzdata" // embed IANA tzdata so the DLL is self-contained
+
 	"github.com/hebcal/hdate"
 	"github.com/hebcal/hebcal-go/event"
 	"github.com/hebcal/hebcal-go/hebcal"


### PR DESCRIPTION
Fixes #3

## Problem

The Go runtime compiled into `HebcalNative.dll` (via CGO) loads IANA timezone data from `C:\Program Files\Go\lib\time\zoneinfo.zip`. This file is part of the Go SDK installation and **does not exist on end-user machines** without Go installed.

When the DLL is invoked from C# (e.g. `HebcalBridge.GetUpcomingShabbat`) and the Go runtime tries to resolve a timezone like `Asia/Jerusalem`, the lookup fails and the runtime triggers a fail-fast (`RaiseFailFastException`, code `0x00000002`), crashing the host process during `MainWindow.Refresh()`.

## Diagnosis

Verified via controlled experiment:
1. ProcMon trace showed 6 `PATH NOT FOUND` lookups for `Go\lib\time\zoneinfo.zip`, the last one ~200ms before the crash.
2. WinDbg crash dump analysis showed the managed stack ending in a P/Invoke to `GetUpcomingShabbat`, with `KERNELBASE!RaiseFailFastException` on the native side.
3. Installing Go SDK (which creates the `zoneinfo.zip` file) made the crash disappear with the original DLL unchanged.
4. Deleting just the contents of `C:\Program Files\Go\lib\` reproduced the crash deterministically. Restoring it restored functionality.

## Fix

Add a single import to `HebcalNative/lib/hebcal_export.go`:

```go
_ "time/tzdata"
```

This is the official Go package (https://pkg.go.dev/time/tzdata) for embedding the IANA timezone database directly into the binary. It adds ~450KB to the DLL but eliminates the runtime filesystem dependency entirely.

## Verification

- Built locally with the change.
- Confirmed the DLL works on a machine where `C:\Program Files\Go\lib\` is empty.
- No code changes required on the C# side.

## Affected users

Any end-user installation without Go SDK present - i.e. essentially all installations from the released installer.
